### PR TITLE
removed quiet so the -z check would function as intended

### DIFF
--- a/lse.sh
+++ b/lse.sh
@@ -916,7 +916,7 @@ lse_run_tests_containers() {
   #check to see if we are in an lxc container
   lse_test "ctn200" "1" \
     "Are we in a lxc container?" \
-    'grep -qa container=lxc /proc/1/environ'
+    'grep -a container=lxc /proc/1/environ'
 
   #is user a member of any lxd/lxc group
   lse_test "ctn210" "0" \


### PR DESCRIPTION
In a quick test, I found that the script would report that we were not in an lxc container when in fact we were (false negative).  

We are in an lxc container:
```
root@-phone:/tmp#cat /proc/1/environ 
PATH=/bin:/sbinTERM=linuxcontainer=lxc-libvirtHOME=/container_uuid=8525a17d-023e-45ae-9a6a-147000345136LIBVIRT_LXC_UUID=8525a17d-023e-45ae-9a6a-147000345136LIBVIRT_LXC_NAME=-phone#                                                       
```
but lse says we're not:

```
root@-phone:/tmp#./lse.sh -s ctn
---
If you know the current user password, write it here for better results: 
---

        User: root
     User ID: 0
    Password: none
        Home: /root
        Path: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
       umask: 0022

    Hostname:-phone
       Linux: 4.10.13-aufs
Architecture: x86_64

=============================================================( containers )=====
[*] ctn000 Are we in a docker container?................................... nope
[*] ctn010 Is docker available?............................................ nope
[!] ctn020 Is the user a member of the 'docker' group?..................... nope
[*] ctn200 Are we in a lxc container?...................................... nope
[!] ctn210 Is the user a member of any lxc/lxd group?...................... nope
root@-phone:/tmp#
```

It looks like the output check (line 246) does a string length check and if it's zero, report `nope`.  Problem here is that the -q on the grep in the ctn200 test will return an exit code of 0 and nothing to stdout.  I figured we'd want the output, both so the $output check would pass and so we could print it when verbosity (-l2) is turned up.

After removing the quiet flag, lse reports that we're in a container as expected:

```
=============================================================( containers )=====
[*] ctn000 Are we in a docker container?................................... nope
[*] ctn010 Is docker available?............................................ nope
[!] ctn020 Is the user a member of the 'docker' group?..................... nope
[*] ctn200 Are we in a lxc container?...................................... yes!
[!] ctn210 Is the user a member of any lxc/lxd group?...................... nope
```