### PR TITLE
fixed error when lsb_release is not available

### DIFF
--- a/lse.sh
+++ b/lse.sh
@@ -75,7 +75,7 @@ lse_home="$HOME"
 lse_arch="`uname -m`"
 lse_linux="`uname -r`"
 lse_hostname="`hostname`"
-lse_distro=`which lsb_release >/dev/null && lsb_release -d | sed 's/Description:\s*//' 2>/dev/null`
+lse_distro=`command -v lsb_release >/dev/null 2>&1 && lsb_release -d | sed 's/Description:\s*//' 2>/dev/null`
 [ -z "$lse_distro" ] && lse_distro="`(source /etc/os-release && echo "$PRETTY_NAME")2>/dev/null`"
 
 # lse
@@ -1081,4 +1081,3 @@ lse_run_tests_containers
 
 lse_exit 0
 #)
-


### PR DESCRIPTION
Just executed your tool on a RedHat-like system without the `lsb_release` executable.

This resulted in the error message:

> which: no lsb_release in (/home/user/.local/bin:/usr/local/sbin:/usr/sbin:/usr/local/bin:/usr/bin:/bin)

The tool still succeeded but I wanted to fix this error. I changed the existence test from `which` to `command -v` as advised in https://stackoverflow.com/a/677212

(PS: thanks for this awesome tool. The output is really pretty! And even the bash code is comprehensible :D )