### PR TITLE
Search for group password hashes in /etc/group

### DIFF
--- a/lse.sh
+++ b/lse.sh
@@ -738,8 +738,13 @@ lse_run_tests_system() {
     "Does the /etc/passwd have hashes?" \
     'grep -v "^[^:]*:[x]" /etc/passwd'
 
+  #check if /etc/group has group password hashes (old system)
+  lse_test "sys022" "0" \
+    "Does the /etc/group have hashes?" \
+    'grep -v "^[^:]*:[x]" /etc/group'
+
   #check if we can read any shadow file
-  for s in 'shadow' 'shadow-' 'shadow~' 'master.passwd'; do
+  for s in 'shadow' 'shadow-' 'shadow~' 'gshadow' 'gshadow-' 'master.passwd'; do
     lse_test "sys030" "0" \
       "Can we read /etc/$s file?" \
       'cat /etc/$s'


### PR DESCRIPTION
Recently, I learned that group passwords exist though they are barely used since the invention of sudo and ACLs :smile:   Also see https://unix.stackexchange.com/a/93125

I discovered such a thing in `/etc/group` during a CTF. I think it makes sense for lse to check that.

I also added `gshadow` and `gshadow-` to the list of shadow files to test for readability.