### PR TITLE
cve-2021-4034: pkexec needs to be setuid root

### DIFF
--- a/cve/cve-2021-4034.sh
+++ b/cve/cve-2021-4034.sh
@@ -51,7 +51,7 @@ lse_cve_test() { #(
   local package_fixed
   pkexec=$(command -v pkexec)
   package_version=$(lse_get_pkg_version polkit)
-  if [ -n "$pkexec" ]; then
+  if [ -n "$pkexec" ] && test -n "$(find "$pkexec" -perm -u+s)"; then
     vulnerable=true
     pkexec_version=$(pkexec --version | grep -Eo '[0-9\.]+')
     if lse_is_version_bigger "$pkexec_version" 0.120 ; then


### PR DESCRIPTION
In order to be vulnerable, `pkexec` needs to be setuid root. I added a check for that.