### PR TITLE
CVE-2021-4034: Detect fixed versions for Fedora

### DIFF
--- a/cve/cve-2021-4034.sh
+++ b/cve/cve-2021-4034.sh
@@ -108,7 +108,18 @@ lse_cve_test() { #(
             ;;
         esac
         ;;
-        #TODO: Add Fedora, RedHat and other distros, although their info about patches is very poor
+      fedora)
+        [ -r "/etc/os-release" ] && distro_release=$(grep -E '^VERSION_ID=' /etc/os-release | cut -f2 -d=)
+        case "$distro_release" in
+          34)
+            package_fixed="0.117-3.fc34.2"
+            ;;
+          35)
+            package_fixed="0.120-1.fc35.1"
+            ;;
+        esac
+        ;;
+      #TODO: Add RedHat and other distros, although their info about patches is very poor
     esac
     if [ -n "$package_fixed" ] && [ -n "$package_version" ] && ! lse_is_version_bigger "$package_fixed" "$package_version"; then
       # Not Vulnerable

--- a/lse.sh
+++ b/lse.sh
@@ -626,6 +626,7 @@ lse_get_pkg_version() { #(
     centos|redhat|fedora|opsuse|rocky)
       pkg_version=`rpm -q "$pkg_name" 2>/dev/null`
       pkg_version="${pkg_version##$pkg_name-}"
+      pkg_version=`echo $pkg_version | sed -E 's/\.(aarch64|armv7hl|i686|noarch|ppc64le|s390x|x86_64)$//'`
       ;;
     *)
       return 2


### PR DESCRIPTION
This adds the fixed versions for Fedora affecting CVE-2021-4034.

In order for this to work, I patched the `lse_get_pkg_version` function because Fedora packages contain an architecture specific suffix, like in `polkit-0.120-1.fc35.2.x86_64`. I remove such suffixes so the version comparison works correctly.