### PR TITLE
Show build instructions if cve list is not populated

### DIFF
--- a/lse.sh
+++ b/lse.sh
@@ -1465,14 +1465,18 @@ lse_run_tests_processes() {
 #########################################################################( CVEs
 lse_run_tests_cves() {
   lse_header "cve" "CVEs"
+  if [ "${#lse_cve_list}" = 1 ]; then
+    echo "In order to test for CVEs, download lse.sh from the GitHub releases page."
+    echo "Alternatively, build lse_cve.sh using tools/package_cvs_into_lse.sh from the repository."
+  else
+    for lse_cve in $lse_cve_list; do
+      eval "$(printf '%s' "$lse_cve" | base64 -d | gunzip -c)"
 
-  for lse_cve in $lse_cve_list; do
-    eval "$(printf '%s' "$lse_cve" | base64 -d | gunzip -c)"
-
-    lse_test "$lse_cve_id" "$lse_cve_level" \
-      "$lse_cve_description" \
-      "lse_cve_test"
-  done
+      lse_test "$lse_cve_id" "$lse_cve_level" \
+        "$lse_cve_description" \
+        "lse_cve_test"
+    done
+  fi
 }
 #)
 #


### PR DESCRIPTION
I think many users are not aware that they need to build lse to get CVE checks.

Currently, the section is completely empty, which might be interpreted as lse checked for CVEs but didn't find any. To guide them towards the right direction, this shows a note if the CVE list has bot been populated by the build script yet.

To be honest, I am also only aware of this feature because I read all of your commits. The README doesn't explain the new CVE checking feature yet.

(While providing feedback on that end, I also know that some people think lse doesn't output anything useful at all, because they only run it with the default verbosity level. Though one can argue that they should RTFM :smile:  But I'm promoting your tool whenever I can... :yum: )