### PR TITLE
Fixed colored echo of current verbosity level

### DIFF
--- a/lse.sh
+++ b/lse.sh
@@ -481,7 +481,7 @@ lse_show_info() { #(
 	fi
   cecho "${lblue}Architecture:${reset} $lse_arch\n"
   echo
-  echo  "${green}=====================(${yellow} Current Output Verbosity Level: ${cyan}$lse_level ${green})======================${reset}"
+  cecho  "${green}=====================(${yellow} Current Output Verbosity Level: ${cyan}$lse_level ${green})======================${reset}"
   echo
 } #)
 lse_serve() { #(


### PR DESCRIPTION
It was printing escape sequences because of the use of `echo` instead of `cecho`.