### PR TITLE
cve-2021-3156: fixed false positives on Amazon Linux

### DIFF
--- a/cve/cve-2021-3156.sh
+++ b/cve/cve-2021-3156.sh
@@ -91,6 +91,17 @@ lse_cve_test() { #(
             ;;
         esac
         ;;
+      amzn)
+        [ -r "/etc/os-release" ] && distro_release=$(grep -E '^VERSION_ID=' /etc/os-release | cut -f2 -d= | tr -d '"')
+        case "$distro_release" in
+          1)
+            package_fixed="1.8.23-9.56.amzn1"
+            ;;
+          2)
+            package_fixed="1.8.23-4.amzn2.2.1"
+            ;;
+        esac
+        ;;
     esac
     if [ -n "$package_fixed" ] && [ -n "$package_version" ] && ! lse_is_version_bigger "$package_fixed" "$package_version"; then
       exit 1
@@ -98,3 +109,6 @@ lse_cve_test() { #(
   fi
   $vulnerable && echo "Vulnerable! sudo version: $sudo_version"
 } #)
+
+# Uncomment this line for testing the lse_cve_test function
+#lse_NO_EXEC=true . ../lse.sh ; lse_cve_test

--- a/lse.sh
+++ b/lse.sh
@@ -625,7 +625,7 @@ lse_get_pkg_version() { #(
     debian|ubuntu)
       pkg_version=`dpkg -l "$pkg_name" 2>/dev/null | grep -E '^ii' | tr -s ' ' | cut -d' ' -f3`
       ;;
-    centos|redhat|fedora|opsuse|rocky)
+    centos|redhat|fedora|opsuse|rocky|amzn)
       pkg_version=`rpm -q "$pkg_name" 2>/dev/null`
       pkg_version="${pkg_version##$pkg_name-}"
       pkg_version=`echo "$pkg_version" | sed -E 's/\.(aarch64|armv7hl|i686|noarch|ppc64le|s390x|x86_64)$//'`


### PR DESCRIPTION
Fixed false positives for CVE-2021-3156 on Amazon Linux, the distribution running in AWS.