### PR TITLE
cve-2021-3156: added patched releases of debian

### DIFF
--- a/cve/cve-2021-3156.sh
+++ b/cve/cve-2021-3156.sh
@@ -68,9 +68,15 @@ lse_cve_test() { #(
       exit 1
     fi
     case "$lse_distro_codename" in
-      ubuntu)
+      debian|ubuntu)
         [ -r "/etc/os-release" ] && distro_release=$(grep -E '^VERSION_CODENAME=' /etc/os-release | cut -f2 -d=)
         case "$distro_release" in
+          stretch)
+            package_fixed="1.8.19p1-2.1+deb9u3"
+            ;;
+          buster)
+            package_fixed="1.8.27-1+deb10u3"
+            ;;
           precise)
             package_fixed="1.8.3p1-1ubuntu3.10"
             ;;


### PR DESCRIPTION
Patched releases of Debian were missing.