### PR TITLE
Fixed parameter substitution in cve scripts

### DIFF
--- a/cve/cve-2021-3560.sh
+++ b/cve/cve-2021-3560.sh
@@ -140,7 +140,7 @@ lse_cve_test() { #(
       exit 1
     fi
   fi
-  $vulnerable && echo "Vulnerable! polkit version: ${package_version:-pkexec_version}"
+  $vulnerable && echo "Vulnerable! polkit version: ${package_version:-$pkexec_version}"
 } #)
 
 # Uncomment this line for testing the lse_cve_test function

--- a/cve/cve-2021-4034.sh
+++ b/cve/cve-2021-4034.sh
@@ -169,7 +169,7 @@ lse_cve_test() { #(
       exit 1
     fi
   fi
-  $vulnerable && echo "Vulnerable! polkit version: ${package_version:-pkexec_version}"
+  $vulnerable && echo "Vulnerable! polkit version: ${package_version:-$pkexec_version}"
 } #)
 
 # Uncomment this line for testing the lse_cve_test function


### PR DESCRIPTION
Unfortunately I had a typo in one of my last contributions, so it was printing a literal string instead of the variable content.