### PR TITLE
Added check for CVE-2023-22809

### DIFF
--- a/cve/cve-2023-22809.sh
+++ b/cve/cve-2023-22809.sh
@@ -1,0 +1,150 @@
+#!/bin/posh
+# shellcheck disable=1003,1091,2006,2016,2034,2039
+# vim: set ts=2 sw=2 sts=2 fdm=marker fmr=#(,#) et:
+#
+# doc:
+#
+#  Copy this file to a new one with the same name of the cve to test, all in
+# lowercase (i.e.: cve-2014–6271.sh).
+#  Then add the code for the functions shown here. **ALL** functions must appear
+# in the new created file, however the ones marked as 'optional' can be left
+# with the same code than in 'skel.sh'. Inside the function, declare all the
+# variables as 'local' (i.e.: local vuln_version="1.2.3")
+#
+#  NOTE: You can use here, functions and variables implemented in 'lse.sh':
+#   * lse_get_pkg_version: Get package version supplying package name
+#   * lse_is_version_bigger: Check if version in $1 is bigger than the $2
+#   * $lse_arch: System architecture
+#   * $lse_distro_codename: The linux distribution code name (ubuntu, debian,
+#      opsuse, centos, redhat, fedora)
+#   * $lse_linux: Kernel version
+#   * Colors
+#  XXX: Check the definitions in 'lse.sh' to better understand what they do and
+#       how they work
+#
+################################################################################
+## RULES:
+##  * Do NOT cause any harm with the tests
+##  * Try to be as accurate as possible, trying to detect patched versions from
+##    distro package versions. Try to minimize false positives.
+##  * The script must be POSIX compliant. Test it with 'posh' shell.
+################################################################################
+
+
+# lse_cve_level: 0 if leads to a privilege escalation; 1 for other CVEs
+lse_cve_level=0
+
+# lse_cve_id: CVE id in lowercase (i.e.: cve-2014–6271)
+lse_cve_id="cve-2023-22809"
+
+# lse_cve_description: Short. Not more than 52 characters long.
+#__________________="vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv"
+lse_cve_description="Sudoedit bypass in Sudo <= 1.9.12p1"
+
+# Code retrieved with 'declare -f' by the packaging bash script
+lse_cve_test() { #(
+  local vulnerable=false
+  local sudo_version
+  local package_version
+  local package_fixed
+  local distro_release
+  if [ -n "$(command -v sudo)" ]; then
+    vulnerable=true
+    sudo_version="$(sudo --version | head -n1 | cut -d ' ' -f 3)"
+    package_version="$(lse_get_pkg_version sudo)"
+    # Versions 1.8.0 through 1.9.12p1 are affected.
+    if lse_is_version_bigger 1.8.0 "$sudo_version"; then
+      exit 1
+    fi
+    if lse_is_version_bigger "$sudo_version" 1.9.12p1; then
+      exit 1
+    fi
+    case "$lse_distro_codename" in
+      debian|ubuntu)
+        [ -r "/etc/os-release" ] && distro_release=$(grep -E '^VERSION_CODENAME=' /etc/os-release | cut -f2 -d=)
+        case "$distro_release" in
+          buster)
+            package_fixed="1.8.27-1+deb10u5"
+            ;;
+          bullseye)
+            package_fixed="1.9.5p2-3+deb11u1"
+            ;;
+          trusty)
+            package_fixed="1.8.9p5-1ubuntu1.5+esm7"
+            ;;
+          xenial)
+            package_fixed="1.8.16-0ubuntu1.10+esm1"
+            ;;
+          bionic)
+            package_fixed="1.8.21p2-3ubuntu1.5"
+            ;;
+          focal)
+            package_fixed="1.8.31-1ubuntu1.4"
+            ;;
+          jammy)
+            package_fixed="1.9.9-1ubuntu2.2"
+            ;;
+          kinetic)
+            package_fixed="1.9.11p3-1ubuntu1.1"
+            ;;
+        esac
+        ;;
+      redhat)
+        [ -r "/etc/os-release" ] && distro_release=$(grep -E '^VERSION_ID=' /etc/os-release | cut -f2 -d=)
+        case "$distro_release" in
+          6.*)
+            package_fixed="1.8.6p3-29.el6_10.7"
+            ;;
+          7.*)
+            package_fixed="1.8.23-10.el7_9.3"
+            ;;
+          8.1)
+            package_fixed="1.8.25p1-8.el8_1.3"
+            ;;
+          8.2)
+            package_fixed="1.8.29-5.el8_2.2"
+            ;;
+          8.4)
+            package_fixed="1.8.29-7.el8_4.2"
+            ;;
+          8.6)
+            package_fixed="1.8.29-8.el8_6.1"
+            ;;
+          8.*)
+            package_fixed="1.8.29-8.el8_7.1"
+            ;;
+          9.0)
+            package_fixed="1.9.5p2-7.el9_0.2"
+            ;;
+          9.*)
+            package_fixed="1.9.5p2-7.el9_1.1"
+            ;;
+          *)
+            lse_is_version_bigger "$distro_release" 9 && exit 1
+            ;;
+        esac
+        ;;
+      amzn)
+        [ -r "/etc/os-release" ] && distro_release=$(grep -E '^VERSION_ID=' /etc/os-release | cut -f2 -d= | tr -d '"')
+        case "$distro_release" in
+          1)
+            package_fixed="1.8.23-10.57.amzn1"
+            ;;
+          2)
+            package_fixed="1.8.23-10.amzn2.3.1"
+            ;;
+          2023)
+            package_fixed="1.9.12-1.p2.amzn2023.0.2"
+            ;;
+        esac
+        ;;
+    esac
+    if [ -n "$package_fixed" ] && [ -n "$package_version" ] && ! lse_is_version_bigger "$package_fixed" "$package_version"; then
+      exit 1
+    fi
+  fi
+  $vulnerable && echo "Vulnerable! sudo version: ${package_version:-$sudo_version}"
+} #)
+
+# Uncomment this line for testing the lse_cve_test function
+#lse_NO_EXEC=true . ../lse.sh ; lse_cve_test

--- a/lse.sh
+++ b/lse.sh
@@ -635,7 +635,7 @@ lse_get_pkg_version() { #(
   pkg_name="$1"
   case "$lse_distro_codename" in
     debian|ubuntu)
-      pkg_version=`dpkg -l "$pkg_name" 2>/dev/null | grep -E '^ii' | tr -s ' ' | cut -d' ' -f3`
+      pkg_version=`dpkg -l "$pkg_name" 2>/dev/null | grep -E '^[ih]i' | tr -s ' ' | cut -d' ' -f3`
       ;;
     centos|redhat|fedora|opsuse|rocky|amzn)
       pkg_version=`rpm -q "$pkg_name" 2>/dev/null`


### PR DESCRIPTION
Added a check for CVE-2023-22809 (Sudoedit bypass in Sudo <= 1.9.12p1).

I also fixed a bug in `lse_get_pkg_version`. A package installed with `dpkg` can be set to hold in order to exclude it from future updates. This is exactly a situation that might lead to a vulnerable version being present on the system. So also match this case.
