### PR TITLE
Fixed RHEL distro detection

### DIFF
--- a/lse.sh
+++ b/lse.sh
@@ -611,6 +611,7 @@ lse_get_distro_codename() { #(
   elif [ -f /etc/os-release ]; then
     distro=`grep -E '^ID=' /etc/os-release | cut -f2 -d=`
     echo "$distro" | grep -qi opensuse && distro=opsuse
+    echo "$distro" | grep -qi rhel && distro=redhat
   elif [ -f /etc/redhat-release ]; then
     grep -qi "centos"  /etc/redhat-release && distro=centos
     grep -qi "fedora"  /etc/redhat-release && distro=fedora


### PR DESCRIPTION
There was a problem in `lse_get_distro_codename`. When `/etc/os-release` exists on a RHEL system, the `ID=rhel` was extracted out of that file and the `/etc/redhat-release` file was never checked in order to set `grep -qi "red hat" /etc/redhat-release && distro=redhat`.

That means, depending on whether `/etc/os-release` exists or not, RHEL was either detected as `rhel` or `redhat`.
This PR fixes this by explicitly setting `redhat` when `rhel` was extracted.

I'm wondering whether it would be cleaner to do it the other way around and just use `rhel` as an identifier for RHEL systems within lse. But that would have required touching more portions of the code and especially all CVE checks.
However, I could do that if you prefer that approach.