### PR TITLE
Find SSH key types ecdsa and ed25519 in "SSH files anywhere" test

### DIFF
--- a/lse.sh
+++ b/lse.sh
@@ -911,7 +911,7 @@ lse_run_tests_filesystem() {
   #check for SSH files anywhere
   lse_test "fst510" "2" \
     "SSH files anywhere" \
-    'find / $lse_find_opts \( -name "*id_dsa*" -o -name "*id_rsa*" -o -name "known_hosts" -o -name "authorized_hosts" -o -name "authorized_keys" \) -exec ls -la {} \;'
+    'find / $lse_find_opts \( -name "*id_dsa*" -o -name "*id_rsa*" -o -name "*id_ecdsa*" -o -name "*id_ed25519*" -o -name "known_hosts" -o -name "authorized_hosts" -o -name "authorized_keys" \) -exec ls -la {} \;'
 
   #dump hosts.equiv file
   lse_test "fst520" "2" \


### PR DESCRIPTION
Prior to this change, the elliptic curve key types were only found in the home directory find test but not in the system-wide test.