### PR TITLE
Skip certain tests when running as root

### DIFF
--- a/lse.sh
+++ b/lse.sh
@@ -381,6 +381,8 @@ lse_test() { #(
   local deps="$5"
   # Variable name where to store the output
   local var="$6"
+  # Flags affecting the execution of certain tests
+  local flags="$7"
 
   # Define colors
   local l="${lred}!"
@@ -407,6 +409,12 @@ lse_test() { #(
   for i in $(seq $((${#id}+${#name}+10)) 79); do
     printf "."
   done
+
+  # Check if test should be skipped when running as root
+  if [ "$lse_user_id" -eq 0 ] && [ "$flags" = "rootskip" ]; then
+    cecho " ${grey}skip\n"
+    return 1
+  fi
 
   # Check dependencies
   local non_met_deps=""
@@ -482,6 +490,10 @@ lse_show_info() { #(
   echo
   cecho  "${green}=====================(${yellow} Current Output Verbosity Level: ${cyan}$lse_level ${green})======================${reset}"
   echo
+  if [ "$lse_user_id" -eq 0 ]; then
+    cecho  "${green}============(${yellow} Already running as ${red}root${yellow}, some tests will be skipped! ${green})============${reset}"
+    echo
+  fi
 } #)
 lse_serve() { #(
   # get port
@@ -778,7 +790,8 @@ lse_run_tests_filesystem() {
     # Add symlinks owned by the user (so the user can change where they point)
     find  / -path "$lse_home" -prune -o $lse_find_opts -type l -user $lse_user -print' \
     "" \
-    "lse_user_writable"
+    "lse_user_writable" \
+    "rootskip"
 
   #get setuid binaries
   lse_test "fst010" "1" \
@@ -906,7 +919,8 @@ lse_run_tests_filesystem() {
   #files owned by user
   lse_test "fst500" "2" \
     "Files owned by user '$lse_user'" \
-    'find / $lse_find_opts -user $lse_user -type f -exec ls -al {} \;'
+    'find / $lse_find_opts -user $lse_user -type f -exec ls -al {} \;' \
+    "" "" "rootskip"
 
   #check for SSH files anywhere
   lse_test "fst510" "2" \


### PR DESCRIPTION
When lse is executed with root permissions, it takes ages to complete and produces dozens of MB of output . This is because the tests "Writable files outside user's home" and "Files owned by user '$lse_user'" match almost everything on the system.

I added functionality to skip such tests when running as root, because the tests do not produce relevant information in this case.
I added a new flag parameter to the test function. But please tell me if you want to have this implemented differently.

One could ask, why run lse as root at all?  I have two use cases for this.

1. If you already took over the system but want to search for some interesting loot on that system, lse could be used in a post exploitation step. For example to find further credentials.

2. Occasionally, I conduct projects for some larger, compliance-driven customers and it can happen that they want us to analyze a server system without letting us access it directly. They run enumeration scripts (like lse) for us and we should draw conclusions from the output. Don't question whether this is useful but sometimes they run the scripts as root.