### PR TITLE
Fix printf color support check

### DIFF
--- a/lse.sh
+++ b/lse.sh
@@ -89,7 +89,7 @@ lse_procmon_lock=`mktemp`
 lse_cve_tmp=''
 
 # printf
-printf "%s" "$reset" | grep -q '\\' && alias printf="env printf"
+printf "$reset" | grep -q '\\' && alias printf="env printf"
 
 #( internal data
 lse_common_setuid="


### PR DESCRIPTION
The "%s" will always print the string literally so you will always resort to the binary printf which in very old systems doesn't support ANSI colors.
This pull request fix issues #32, #38 and #67. 